### PR TITLE
feat: add user registration

### DIFF
--- a/src/AuthServerKeyCloak.Api/Controllers/AuthController.cs
+++ b/src/AuthServerKeyCloak.Api/Controllers/AuthController.cs
@@ -1,6 +1,5 @@
-﻿using AuthServerKeyCloak.Api.Models;
+using AuthServerKeyCloak.Api.Models;
 using AuthServerKeyCloak.Api.Services;
-using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
 namespace AuthServerKeyCloak.Api.Controllers
@@ -21,6 +20,13 @@ namespace AuthServerKeyCloak.Api.Controllers
         {
             var response = await _keycloakServices.GetTokenAsync(model);
             return Ok(response);
+        }
+
+        [HttpPost("register")]
+        public async Task<ActionResult> Register([FromBody] RegisterModel model)
+        {
+            await _keycloakServices.CreateUserAsync(model);
+            return Ok();
         }
     }
 }

--- a/src/AuthServerKeyCloak.Api/Models/RegisterModel.cs
+++ b/src/AuthServerKeyCloak.Api/Models/RegisterModel.cs
@@ -1,0 +1,12 @@
+using System;
+namespace AuthServerKeyCloak.Api.Models
+{
+    public class RegisterModel
+    {
+        public string Username { get; set; }
+        public string FirstName { get; set; }
+        public string LastName { get; set; }
+        public string Email { get; set; }
+        public string Password { get; set; }
+    }
+}

--- a/src/AuthServerKeyCloak.Api/Services/KeycloakServices.cs
+++ b/src/AuthServerKeyCloak.Api/Services/KeycloakServices.cs
@@ -1,13 +1,13 @@
-﻿using AuthServerKeyCloak.Api.Models;
-using System.Runtime;
-using System.Text.Json;
-using static System.Net.WebRequestMethods;
+using AuthServerKeyCloak.Api.Models;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
 
 namespace AuthServerKeyCloak.Api.Services
 {
     public interface IKeycloakServices
     {
         Task<LoginResponse> GetTokenAsync(LoginModel loginModel);
+        Task CreateUserAsync(RegisterModel registerModel);
     }
 
     public class KeycloakServices : IKeycloakServices
@@ -32,7 +32,6 @@ namespace AuthServerKeyCloak.Api.Services
                 new KeyValuePair<string, string>("grant_type", "password")
             });
 
-
             var endpoint = _configuration.GetValue<string>("Keycloak:Endpoints:Token");
             var response = await _httpClient.PostAsync(endpoint, content);
 
@@ -40,6 +39,41 @@ namespace AuthServerKeyCloak.Api.Services
 
             var keycloakToken = await response.Content.ReadFromJsonAsync<KeycloakToken>();
             return new LoginResponse(keycloakToken);
+        }
+
+        public async Task CreateUserAsync(RegisterModel registerModel)
+        {
+            var adminLogin = new LoginModel
+            {
+                Username = _configuration.GetValue<string>("Keycloak:AdminUser:Username"),
+                Password = _configuration.GetValue<string>("Keycloak:AdminUser:Password")
+            };
+
+            var adminToken = await GetTokenAsync(adminLogin);
+
+            var userData = new
+            {
+                firstName = registerModel.FirstName,
+                lastName = registerModel.LastName,
+                email = registerModel.Email,
+                username = registerModel.Username,
+                enabled = true,
+                credentials = new[]
+                {
+                    new { type = "password", value = registerModel.Password, temporary = false }
+                }
+            };
+
+            var endpoint = _configuration.GetValue<string>("Keycloak:AdminUrl") + _configuration.GetValue<string>("Keycloak:Endpoints:Users");
+
+            var request = new HttpRequestMessage(HttpMethod.Post, endpoint)
+            {
+                Content = JsonContent.Create(userData)
+            };
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", adminToken.AccessToken);
+
+            var response = await _httpClient.SendAsync(request);
+            response.EnsureSuccessStatusCode();
         }
     }
 }

--- a/src/AuthServerKeyCloak.Api/appsettings.Development.json
+++ b/src/AuthServerKeyCloak.Api/appsettings.Development.json
@@ -7,10 +7,16 @@
   },
   "Keycloak": {
     "BaseUrl": "http://localhost:8080/realms/AuthServer/",
+    "AdminUrl": "http://localhost:8080/admin/realms/AuthServer/",
     "ClientId": "auth-server-keycloak",
     "ClientSecret": "",
+    "AdminUser": {
+      "Username": "",
+      "Password": ""
+    },
     "Endpoints": {
-      "Token": "protocol/openid-connect/token"
+      "Token": "protocol/openid-connect/token",
+      "Users": "users"
     }
   }
 }

--- a/src/AuthServerKeyCloak.Api/appsettings.json
+++ b/src/AuthServerKeyCloak.Api/appsettings.json
@@ -7,10 +7,16 @@
   },
   "Keycloak": {
     "BaseUrl": "http://localhost:8080/realms/AuthServer/",
+    "AdminUrl": "http://localhost:8080/admin/realms/AuthServer/",
     "ClientId": "auth-server-keycloak",
     "ClientSecret": "",
+    "AdminUser": {
+      "Username": "",
+      "Password": ""
+    },
     "Endpoints": {
-      "Token": "protocol/openid-connect/token"
+      "Token": "protocol/openid-connect/token",
+      "Users": "users"
     }
   },
   "AllowedHosts": "*"


### PR DESCRIPTION
## Summary
- add user registration controller endpoint
- create Keycloak service method to register users
- configure admin credentials and user endpoint

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68976f9b59ec8329998d24c085af6c05